### PR TITLE
Set the AppRated Flag to NO if the user is unable to open URL

### DIFF
--- a/ApptentiveConnect/source/Rating Flow/ATAppRatingFlow.m
+++ b/ApptentiveConnect/source/Rating Flow/ATAppRatingFlow.m
@@ -61,7 +61,7 @@ static ATAppRatingFlow *sharedRatingFlow = nil;
 - (void)setRatingDialogWasShown;
 - (void)setUserDislikesThisVersion;
 - (void)setDeclinedToRateThisVersion;
-- (void)setRatedApp;
+- (void)setRatedApp:(BOOL)hasRated;
 - (void)logDefaults;
 
 #if TARGET_OS_IPHONE
@@ -385,12 +385,13 @@ static ATAppRatingFlow *sharedRatingFlow = nil;
 - (void)showUnableToOpenAppStoreDialog {
 	UIAlertView *errorAlert = [[[UIAlertView alloc] initWithTitle:ATLocalizedString(@"Oops!", @"Unable to load the App Store title") message:ATLocalizedString(@"Unable to load the App Store", @"Unable to load the App Store message") delegate:nil cancelButtonTitle:ATLocalizedString(@"Okay", @"Okay button title") otherButtonTitles:nil] autorelease];
 	[errorAlert show];
+	[self setRatedApp:NO];
 }
 #endif
 
 - (void)openURLForRatingApp {
 	NSURL *url = [self URLForRatingApp];
-	[self setRatedApp];
+	[self setRatedApp:YES];
 #if TARGET_OS_IPHONE
 	if ([SKStoreProductViewController class] != NULL && iTunesAppID) {
 #if TARGET_IPHONE_SIMULATOR
@@ -596,9 +597,9 @@ static ATAppRatingFlow *sharedRatingFlow = nil;
 	[defaults synchronize];
 }
 
-- (void)setRatedApp {
+- (void)setRatedApp:(BOOL)hasRated {
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-	[defaults setObject:[NSNumber numberWithBool:YES] forKey:ATAppRatingFlowRatedAppKey];
+	[defaults setObject:[NSNumber numberWithBool:hasRated] forKey:ATAppRatingFlowRatedAppKey];
 	[defaults synchronize];
 }
 


### PR DESCRIPTION
The AppRated flag currently gets set when a user chooses that they would like to rate the application.   This will make the popup never show up again unless the version changes.  

The only problem with this is if the user gets a error either opening the URL or with the StoreKit, the user will never get requested to try and rate the app again.  

This commit would set the ATAppRatingFlowRatedAppKey to NO if they get an error opening the URL or the StoreKit returns an error.   My thought is this would help for intermittent network issues potential, the only concern would be if the error is consistent the user would keep getting a ratings popup.  
Thoughts about the last concern?   Maybe there is better error checking to be done in the StoreKit completionBlock.

Cheers!
-Kevin
