### PR TITLE
New podspec to use source instead of Lib

### DIFF
--- a/apptentive-ios.podspec
+++ b/apptentive-ios.podspec
@@ -11,8 +11,7 @@ Pod::Spec.new do |s|
   s.exclude_files = 'ApptentiveConnect/ext/PrefixedTTTAttributedLabel/Example/*.*'
   s.requires_arc = false
   s.frameworks     = 'CoreGraphics', 'Foundation', 'QuartzCore', 'SystemConfiguration', 'UIKit', 'CoreData', 'CoreText'
-  s.resources = 'ApptentiveConnect/xibs/**/*.*', 'ApptentiveConnect/resources/localization/*.*', 'ApptentiveConnect/source/Model/*.xcdatamodeld', 'ApptentiveConnect/art/generated'
-  s.resource_bundle = { 'ApptentiveResources' => 'ApptentiveConnect/source/Model/*.xcdatamodeld' }
+  s.resource_bundle = { 'ApptentiveResources' => ['ApptentiveConnect/source/Model/*.xcdatamodeld', 'ApptentiveConnect/xibs/**/*.*', 'ApptentiveConnect/resources/localization/English.lproj','ApptentiveConnect/art/generated/**/*.*'] }
   s.weak_frameworks = 'StoreKit', 'CoreTelephony'
   s.prefix_header_contents = '#import "ATLog.h"'
   s.xcconfig = { "GCC_PREPROCESSOR_DEFINITIONS" =>  "TTTATTRIBUTEDLABEL_PREFIX=AT  JSONKIT_PREFIX=AT APPTENTIVE_DEBUG_LOG_VIEWER=1 AT_LOGGING_LEVEL_INFO=1 AT_LOGGING_LEVEL_ERROR=1" }


### PR DESCRIPTION
This will make it easier to use the latest code updates and tags without having to release binaries.  Also, it'll make it simpler for people to use internal podspec repos and custom implementations of ApptentiveConnect. 

Note: bug https://github.com/CocoaPods/CocoaPods/issues/1309 from cocaopods which should get pulled into .24.1 release of cocoapods will allow resource_bundles for targets other then Debug, and Release.  In .24 it's completely broken and in .23 it will only support Debug and Release targets.
