### PR TITLE
Fix double alloc of persistent store coordinator

### DIFF
--- a/ApptentiveConnect/source/Persistence/ATDataManager.m
+++ b/ApptentiveConnect/source/Persistence/ATDataManager.m
@@ -90,7 +90,6 @@ typedef enum {
 			ATLogError(@"Unable to setup persistent store: %@", exception);
 			return nil;
 		}
-		persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[self managedObjectModel]];
 		BOOL storeExists = [[NSFileManager defaultManager] fileExistsAtPath:[storeURL path]];
 		
 		if (storeExists && [self isMigrationNecessary:persistentStoreCoordinator]) {


### PR DESCRIPTION
_Possible fix for an apparent leak in ATDataManager_

ATDataManager lazily allocates a persistent store coordinator inside a try/catch harness, but the code path followed where no exception is thrown repeats the allocation and assigns it to the var, causing a leak.

The leak shows up in Instruments on the first call to -[ATConnect setApiKey:@""] (or anything else that triggers instantiation of the lazy ivar).
