### PR TITLE
Fix truncation issue by adjusting width

### DIFF
--- a/ApptentiveConnect/source/Message Center/ATTextMessageUserCell.m
+++ b/ApptentiveConnect/source/Message Center/ATTextMessageUserCell.m
@@ -103,7 +103,7 @@
 			cellHeight += self.dateLabel.bounds.size.height;
 		}
 		cellHeight += self.usernameLabel.bounds.size.height;
-		CGFloat textWidth = width - 101;
+		CGFloat textWidth = width - 115;
 		CGFloat heightPadding = 19 + 6;
 		CGSize textSize = [self.messageText sizeThatFits:CGSizeMake(textWidth, 2000)];
 		cellHeight += MAX(60, textSize.height + heightPadding);


### PR DESCRIPTION
This fixes the truncation issue mentioned in issue #65, at least in the example I had. You may want to verify the width is precisely correct now, I got as close as possible, but might have overshot a bit since I was just measuring with Xscope.

Also I didn't test in the landscape orientation at all, so perhaps some conditional logic is required if -101 was correct for that mode.
