### PR TITLE
Version 1.5.3

### DIFF
--- a/ApptentiveConnect/source/ATConnect.h
+++ b/ApptentiveConnect/source/ATConnect.h
@@ -13,7 +13,7 @@
 #import <Cocoa/Cocoa.h>
 #endif
 
-#define kATConnectVersionString @"1.5.2"
+#define kATConnectVersionString @"1.5.3"
 
 #if TARGET_OS_IPHONE
 #	define kATConnectPlatformString @"iOS"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+2014-06-30 pkamb v1.5.3
+--------------------------------
+
+This release fixes an issue where the Rating Prompt's "Require Email" option was not being utilized.
+
+Support has also been added for remote configuration of Apptentive branding. Depending on your Apptentive plan, branding can now be toggled remotely.
+
+Branding was formerly controlled by the `showTagLine` property, which has now been removed. The `initiallyHideBranding` property has been provided to control the app's initial experience before Apptentive's server-based configuration can be fetched.
+
 2014-06-12 pkamb v1.5.2
 --------------------------------
 

--- a/apptentive-ios.podspec
+++ b/apptentive-ios.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'apptentive-ios'
-  s.version  = '1.5.2'
+  s.version  = '1.5.3'
   s.license  = 'BSD'
   s.summary  = 'Apptentive Customer Communications SDK.'
   s.homepage = 'https://www.apptentive.com/'


### PR DESCRIPTION
This release fixes an issue where the Rating Prompt's "Require Email" option was not being utilized.

Support has also been added for remote configuration of Apptentive branding. Depending on your Apptentive plan, branding can now be toggled remotely.

Branding was formerly controlled by the `showTagLine` property, which has now been removed. The `initiallyHideBranding` property has been provided to control the app's initial experience before Apptentive's server-based configuration can be fetched.
