### PR TITLE
Added new App Store URL for iOS 7.1+ devices.

### DIFF
--- a/ApptentiveConnect/source/Engagement/Controllers/ATInteractionAppStoreController.m
+++ b/ApptentiveConnect/source/Engagement/Controllers/ATInteractionAppStoreController.m
@@ -103,7 +103,9 @@ NSString *const ATInteractionAppStoreRatingEventLabelUnableToRate = @"unable_to_
 	NSString *URLString = nil;
 	
 #if TARGET_OS_IPHONE
-	if ([ATUtilities osVersionGreaterThanOrEqualTo:@"6.0"]) {
+	if ([ATUtilities osVersionGreaterThanOrEqualTo:@"7.1"]) {
+		URLString = [NSString stringWithFormat:@"itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?type=Purple+Software&id=%@", [self appID]];
+	} else if ([ATUtilities osVersionGreaterThanOrEqualTo:@"6.0"]) {
 		URLString = [NSString stringWithFormat:@"itms-apps://itunes.apple.com/%@/app/id%@", [[NSLocale currentLocale] objectForKey: NSLocaleCountryCode], [self appID]];
 	} else {
 		URLString = [NSString stringWithFormat:@"itms-apps://ax.itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?type=Purple+Software&id=%@", [self appID]];


### PR DESCRIPTION
New URL opens "Reviews" tab directly, rather than the main App Store page.
Fixes IOS-567

Targeting the "Reviews" tab was broken on iOS 7.0 devices. Seems to be fixed in iOS 7.1.

Note that this new URL is missing the "ax" in the URL: "itms-apps://**ax.**itunes.apple..." as seen in the legacy iOS 5-era URL in the case below. When the "ax." is included in the URL, the app store page does not open in iOS 7.1.1

![tab](https://cloud.githubusercontent.com/assets/342355/3503477/ae0438c0-0631-11e4-9c0f-7c5f326ca9a8.png)
