### PR TITLE
Tinting the Profile button in iOS 6

### DIFF
--- a/ApptentiveConnect/source/Message Center/ATMessageCenterBaseViewController.m
+++ b/ApptentiveConnect/source/Message Center/ATMessageCenterBaseViewController.m
@@ -101,9 +101,9 @@
 			button.frame = CGRectMake(0.0, 0.0, buttonImage.size.width, buttonImage.size.height);
 			[button addTarget:self action:@selector(settingsPressed:) forControlEvents:UIControlEventTouchUpInside];
 			
-			profileButtonItem = [[UIBarButtonItem alloc] initWithCustomView:button];
+			profileButtonItem = [[[UIBarButtonItem alloc] initWithCustomView:button] autorelease];
 		} else {
-			profileButtonItem = [[[UIBarButtonItem alloc] initWithImage:[ATBackend imageNamed:@"at_user_button_image"] landscapeImagePhone:[ATBackend imageNamed:@"at_user_button_image_landscape"] style:UIBarButtonItemStylePlain target:self action:@selector(settingsPressed:)]autorelease];
+			profileButtonItem = [[[UIBarButtonItem alloc] initWithImage:[ATBackend imageNamed:@"at_user_button_image"] landscapeImagePhone:[ATBackend imageNamed:@"at_user_button_image_landscape"] style:UIBarButtonItemStylePlain target:self action:@selector(settingsPressed:)] autorelease];
 		}
 		
 		self.navigationItem.rightBarButtonItem = profileButtonItem;

--- a/ApptentiveConnect/source/Message Center/ATMessageCenterBaseViewController.m
+++ b/ApptentiveConnect/source/Message Center/ATMessageCenterBaseViewController.m
@@ -25,6 +25,7 @@
 #import "ATTaskQueue.h"
 #import "ATTextMessage.h"
 #import "ATUtilities.h"
+#import "UIImage+ATImageEffects.h"
 
 @interface ATMessageCenterBaseViewController ()
 - (void)showSendImageUIIfNecessary;
@@ -90,7 +91,22 @@
 	self.navigationItem.titleView = [defaultTheme titleViewForMessageCenterViewController:self];
 	self.navigationItem.leftBarButtonItem = [[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(donePressed:)] autorelease];
 	if ([self.navigationItem.leftBarButtonItem respondsToSelector:@selector(initWithImage:landscapeImagePhone:style:target:action:)]) {
-		self.navigationItem.rightBarButtonItem = [[[UIBarButtonItem alloc] initWithImage:[ATBackend imageNamed:@"at_user_button_image"] landscapeImagePhone:[ATBackend imageNamed:@"at_user_button_image_landscape"] style:UIBarButtonItemStylePlain target:self action:@selector(settingsPressed:)]autorelease];
+		UIBarButtonItem *profileButtonItem;
+		
+		if (![ATUtilities osVersionGreaterThanOrEqualTo:@"7.0"] && [ATConnect sharedConnection].tintColor) {
+			// Tint color for the profile button in iOS 6 and below.
+			UIImage *buttonImage = [[ATBackend imageNamed:@"at_user_button_image"] imageByTintingWithColor:[ATConnect sharedConnection].tintColor];
+			UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
+			[button setImage:buttonImage forState:UIControlStateNormal];
+			button.frame = CGRectMake(0.0, 0.0, buttonImage.size.width, buttonImage.size.height);
+			[button addTarget:self action:@selector(settingsPressed:) forControlEvents:UIControlEventTouchUpInside];
+			
+			profileButtonItem = [[UIBarButtonItem alloc] initWithCustomView:button];
+		} else {
+			profileButtonItem = [[[UIBarButtonItem alloc] initWithImage:[ATBackend imageNamed:@"at_user_button_image"] landscapeImagePhone:[ATBackend imageNamed:@"at_user_button_image_landscape"] style:UIBarButtonItemStylePlain target:self action:@selector(settingsPressed:)]autorelease];
+		}
+		
+		self.navigationItem.rightBarButtonItem = profileButtonItem;
 		self.navigationItem.rightBarButtonItem.accessibilityLabel = ATLocalizedString(@"Contact Settings", @"Title of contact information edit screen");
 	} else {
 		self.navigationItem.rightBarButtonItem = [[[UIBarButtonItem alloc] initWithImage:[ATBackend imageNamed:@"at_user_button_image"] style:UIBarButtonItemStylePlain target:self action:@selector(settingsPressed:)]autorelease];

--- a/ApptentiveConnect/source/Misc/UIImage+ATImageEffects.h
+++ b/ApptentiveConnect/source/Misc/UIImage+ATImageEffects.h
@@ -103,6 +103,9 @@
 - (UIImage *)at_applyTintEffectWithColor:(UIColor *)tintColor;
 
 - (UIImage *)at_applyBlurWithRadius:(CGFloat)blurRadius tintColor:(UIColor *)tintColor saturationDeltaFactor:(CGFloat)saturationDeltaFactor maskImage:(UIImage *)maskImage;
+
+- (UIImage *)imageByTintingWithColor:(UIColor *)color;
+
 @end
 
 void ATImageEffects_UIImage_Bootstrap();

--- a/ApptentiveConnect/source/Misc/UIImage+ATImageEffects.m
+++ b/ApptentiveConnect/source/Misc/UIImage+ATImageEffects.m
@@ -274,6 +274,28 @@
     UIGraphicsEndImageContext();
     return outputImage;
 }
+
+- (UIImage *)imageByTintingWithColor:(UIColor *)color {
+	UIGraphicsBeginImageContextWithOptions(self.size, NO, [[UIScreen mainScreen] scale]);
+	CGContextRef context = UIGraphicsGetCurrentContext();
+	
+	[color setFill];
+	CGContextSetBlendMode(context, kCGBlendModeNormal);
+	CGContextTranslateCTM(context, 0, self.size.height);
+	CGContextScaleCTM(context, 1.0, -1.0);
+	
+	CGRect rect = CGRectMake(0, 0, self.size.width, self.size.height);
+	CGContextDrawImage(context, rect, self.CGImage);
+	CGContextClipToMask(context, rect, self.CGImage);
+	CGContextAddRect(context, rect);
+	CGContextDrawPath(context, kCGPathFill);
+	
+	UIImage *tinted = UIGraphicsGetImageFromCurrentImageContext();
+	UIGraphicsEndImageContext();
+	
+	return tinted;
+}
+
 @end
 
 void ATImageEffects_UIImage_Bootstrap() {


### PR DESCRIPTION
Similar to what is done automatically in iOS 7.
This looks better when the navigation item has been customized to be white.
Fixes IOS-535
