### PR TITLE
Add undef before defining AT_LOGGING_LEVEL_INFO to prevent warning

### DIFF
--- a/ApptentiveConnect/source/Misc/ATLog.h
+++ b/ApptentiveConnect/source/Misc/ATLog.h
@@ -14,6 +14,7 @@
 // So, do it explicitly.
 #if COCOAPODS
 #if DEBUG
+#undef AT_LOGGING_LEVEL_INFO
 #define AT_LOGGING_LEVEL_INFO 1
 #endif
 #endif


### PR DESCRIPTION
This removes the only warning when installing with CocoaPods. It doesn't change the functionality.