### PR TITLE
Fix : Changing greeting view background colour as per Doc

### DIFF
--- a/ApptentiveConnect/source/Message Center/Controllers/ApptentiveMessageCenterViewController.m
+++ b/ApptentiveConnect/source/Message Center/Controllers/ApptentiveMessageCenterViewController.m
@@ -152,7 +152,7 @@ typedef NS_ENUM(NSInteger, ATMessageCenterState) {
 	self.tableView.separatorColor = [[Apptentive sharedConnection].styleSheet colorForStyle:ApptentiveColorSeparator];
 	self.tableView.backgroundColor = [[Apptentive sharedConnection].styleSheet colorForStyle:ApptentiveColorCollectionBackground];
 
-	self.greetingView.backgroundColor = [[Apptentive sharedConnection].styleSheet colorForStyle:ApptentiveColorBackground];
+	self.greetingView.backgroundColor = [[Apptentive sharedConnection].styleSheet colorForStyle:ApptentiveColorHeaderBackground];
 	self.greetingView.borderView.backgroundColor = [[Apptentive sharedConnection].styleSheet colorForStyle:ApptentiveColorSeparator];
 
 	self.greetingView.titleLabel.text = self.interaction.greetingTitle;


### PR DESCRIPTION
<img width="476" alt="settingheaderbackgroundstyle" src="https://cloud.githubusercontent.com/assets/17270351/20351553/6032847a-ac39-11e6-9707-2c4e70bb719e.png">

As per the documentation for customising Apptentive UI, header background colour should be used for  greeting view background colour. 

https://learn.apptentive.com/knowledge-base/interface-customization-ios/