### PR TITLE
Fix warning: MobileCoreServices has been renamed. Use CoreServices instead.

### DIFF
--- a/apptentive-ios.podspec
+++ b/apptentive-ios.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform = :ios, '9.0'
   s.source_files   = 'Apptentive/Apptentive/**/*.{h,m}'
   s.requires_arc = true
-  s.frameworks     = 'AVFoundation', 'CoreData', 'CoreGraphics', 'Foundation', 'ImageIO', 'MobileCoreServices', 'QuartzCore', 'QuickLook', 'SystemConfiguration', 'UIKit'
+  s.frameworks     = 'AVFoundation', 'CoreData', 'CoreGraphics', 'Foundation', 'ImageIO', 'QuartzCore', 'QuickLook', 'SystemConfiguration', 'UIKit'
   s.resource_bundle = { 'ApptentiveResources' => [
 		'Apptentive/Apptentive/Model/*.xcdatamodeld',
 		'Apptentive/Apptentive/Model/*.xcmappingmodel',


### PR DESCRIPTION
Close #262

If our library was installed via CocoaPods, Xcode 11.4 will issue the warning "MobileCoreServices has been renamed. Use CoreServices instead.".

![image](https://user-images.githubusercontent.com/526008/77892980-eecffd80-72a5-11ea-891b-78acd78d4b7c.png)

How to fix: Do not explicitly link `MobileCoreServices.framework` in the CocoaPods generated project, by deleting `MobileCoreServices` from the `spec.frameworks` attribute in our podspec file.

More info: https://github.com/AFNetworking/AFNetworking/pull/4532
