### PR TITLE
Added a notification for when a user cancels a survey.

### DIFF
--- a/Apptentive/Apptentive/Apptentive.h
+++ b/Apptentive/Apptentive/Apptentive.h
@@ -79,6 +79,9 @@ extern NSNotificationName const ApptentiveSurveyShownNotification;
 /** Notification sent when a survey is submitted by the user. */
 extern NSNotificationName const ApptentiveSurveySentNotification;
 
+/** Notification sent when a survey is cancelled. */
+extern NSNotificationName const ApptentiveSurveyCancelledNotification;
+
 /** Notification sent when a message is sent, either by the user or using a sendAttachment method.
  You can use this notification to ask the user to enable push notifications. */
 extern NSNotificationName const ApptentiveMessageSentNotification;

--- a/Apptentive/Apptentive/Apptentive.m
+++ b/Apptentive/Apptentive/Apptentive.m
@@ -35,6 +35,7 @@ NSNotificationName const ApptentiveAppRatingFlowUserAgreedToRateAppNotification 
 
 NSNotificationName const ApptentiveSurveyShownNotification = @"ApptentiveSurveyShownNotification";
 NSNotificationName const ApptentiveSurveySentNotification = @"ApptentiveSurveySentNotification";
+NSNotificationName const ApptentiveSurveyCancelledNotification = @"ApptentiveSurveyCancelledNotification";
 
 NSNotificationName const ApptentiveCustomPersonDataChangedNotification = @"ApptentiveCustomPersonDataChangedNotification";
 NSNotificationName const ApptentiveCustomDeviceDataChangedNotification = @"ApptentiveCustomDeviceDataChangedNotification";

--- a/Apptentive/Apptentive/Surveys/View Controllers/ApptentiveSurveyViewModel.m
+++ b/Apptentive/Apptentive/Surveys/View Controllers/ApptentiveSurveyViewModel.m
@@ -520,6 +520,7 @@ NSString *const ApptentiveInteractionSurveyEventLabelCancel = @"cancel";
 }
 
 - (void)didCancel:(UIViewController *)presentingViewController {
+    [[NSNotificationCenter defaultCenter] postNotificationName:ApptentiveSurveyCancelledNotification object:nil];
 	[Apptentive.shared.backend engage:ApptentiveInteractionSurveyEventLabelCancel fromInteraction:self.interaction fromViewController:presentingViewController];
 }
 


### PR DESCRIPTION
Fixes Issue 271. 

3 lines of code that allows a notification to be sent when the user cancels the survey

https://github.com/apptentive/apptentive-ios/issues/271