### PR TITLE
ApptentiveLogMonitor: Adds debug compiler flag to startSessionWithBaseURL to prevent pasteboard notification

### DIFF
--- a/Apptentive/Apptentive/Misc/ApptentiveLogMonitor.m
+++ b/Apptentive/Apptentive/Misc/ApptentiveLogMonitor.m
@@ -75,7 +75,7 @@ static ApptentiveLogMonitorSession * _currentSession;
 		ApptentiveLogInfo(ApptentiveLogTagMonitor, @"Previous Apptentive Log Monitor session loaded from persistent storage: %@", session);
 		[self startSession:session];
 	} else {
-#ifdef DEBUG
+#ifdef APPTENTIVE_DEBUG
 		// attempt to read access token from a clipboard
 		NSString *accessToken = [self readAccessTokenFromClipboard];
 		if (accessToken == nil) {

--- a/Apptentive/Apptentive/Misc/ApptentiveLogMonitor.m
+++ b/Apptentive/Apptentive/Misc/ApptentiveLogMonitor.m
@@ -75,6 +75,7 @@ static ApptentiveLogMonitorSession * _currentSession;
 		ApptentiveLogInfo(ApptentiveLogTagMonitor, @"Previous Apptentive Log Monitor session loaded from persistent storage: %@", session);
 		[self startSession:session];
 	} else {
+#ifdef DEBUG
 		// attempt to read access token from a clipboard
 		NSString *accessToken = [self readAccessTokenFromClipboard];
 		if (accessToken == nil) {
@@ -106,6 +107,7 @@ static ApptentiveLogMonitorSession * _currentSession;
 			// start session
 			[self startSession:session];
 		}];
+#endif
 	}
 }
 


### PR DESCRIPTION
**Reason:**
In iOS 14 users can now see when we are calling the pasteboard. When the Apptentive sdk fails to start ApptentiveLogMonitor, users are made aware of this, and believe the app is snooping on them. 

After further investigation, I have found `ApptentiveLogMonitor` constantly fails to start on iOS 13 & 14 (haven't been able to verify iOS 12 and below) which leads to every time you open the app `ApptentiveLogMonitor` looking at the clipboard and then if it is of a certain format send that code off to Apptentive servers.

A malicious user could send anything to the `/debug/verify` which could impact the Apptentive service. This PR stops `release` build of the application from looking at the pasteboard, and from sending anything of suitable format to the apptentive endpoint `/debug/verify`

**Related Issue:**
https://github.com/apptentive/apptentive-ios/issues/274

**Changes:**
Adds debug compiler flag around debug only code in Apptentive
