### PR TITLE
Make writing of log file configurable

### DIFF
--- a/Apptentive/Apptentive/Apptentive.m
+++ b/Apptentive/Apptentive/Apptentive.m
@@ -103,6 +103,7 @@ static Apptentive *_nullInstance;
 		_logLevel = ApptentiveLogLevelInfo;
 		_shouldSanitizeLogMessages = YES;
 		_showInfoButton = YES;
+		_enableDebugLogFile = YES;
 	}
 	return self;
 }
@@ -155,7 +156,9 @@ static Apptentive *_nullInstance;
 		_operationQueue = [ApptentiveDispatchQueue createQueueWithName:@"Apptentive Main Queue" concurrencyType:ApptentiveDispatchQueueConcurrencyTypeSerial qualityOfService:NSQualityOfServiceUserInitiated];
 		
 		// start log writer
-		ApptentiveStartLogMonitor([ApptentiveUtilities cacheDirectoryPath:@"com.apptentive.logs"]);
+		if (configuration.enableDebugLogFile) {
+			ApptentiveStartLogMonitor([ApptentiveUtilities cacheDirectoryPath:@"com.apptentive.logs"]);
+		}
 
 		// start log monitor
 		[ApptentiveLogMonitor startSessionWithBaseURL:configuration.baseURL appKey:configuration.apptentiveKey signature:configuration.apptentiveSignature queue:_operationQueue];

--- a/Apptentive/Apptentive/ApptentiveMain.h
+++ b/Apptentive/Apptentive/ApptentiveMain.h
@@ -162,6 +162,9 @@ typedef NS_ENUM(NSUInteger, ApptentiveLogLevel) {
 /** If set, redacts potentially-sensitive information such as user data and credentials from logging. */
 @property (assign, nonatomic) BOOL shouldSanitizeLogMessages;
 
+/** Determines if the SDK will write a debug log file in the cache directory (defaults to YES)  */
+@property (assign, nonatomic) BOOL enableDebugLogFile;
+
 /** The server URL to use for API calls. Should only be used for testing. */
 @property (copy, nonatomic) NSURL *baseURL;
 


### PR DESCRIPTION
For us to be able to integrate your SDK in our product we have a 3rd party security requirement that the SDK does not write a debug log file to the Caches directory. In this PR I've made the creation of this log file configurable and left the default behaviour to the existing situation. Hopefully you guys can integrate this one, it would greatly help us. Thanks in advance and don't hesitate to contact me if there's any comments!

Kind regards,
Benjamin van den Hout